### PR TITLE
Add optional import  of `pathos` for more robust multiprocessing support

### DIFF
--- a/pyswarm/pso.py
+++ b/pyswarm/pso.py
@@ -118,8 +118,12 @@ def pso(func, lb, ub, ieqcons=[], f_ieqcons=None, args=(), kwargs={},
 
     # Initialize the multiprocessing module if necessary
     if processes > 1:
-        import multiprocessing
-        mp_pool = multiprocessing.Pool(processes)
+        try:
+            from pathos.multiprocessing import ProcessingPool as Pool
+        except ImportError:
+            from multiprocessing import Pool
+        
+        mp_pool = Pool(processes)
         
     # Initialize the particle swarm ############################################
     S = swarmsize


### PR DESCRIPTION
The `multiprocessing`built-in uses pickle, which fails for functions defined outside the top-level of a module.  

Although not perhaps the best idea, it can be _convenient_ to define a loss function inside another function, leading to a closure of shared/'global' parameters from one to the other. `pickle` fails here.

In this request, I've added an optional import of the `pathos` multiprocessing lib, which uses `dill` -
 a more flexible serialization option.