### PR TITLE
fix + feat: resolve 10 stale issues in a single PR

### DIFF
--- a/pyswarm/pso.py
+++ b/pyswarm/pso.py
@@ -56,6 +56,7 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
     patience: int = 0,
     bounds: list[tuple[float, float]] | None = None,
     pool: object | None = None,
+    init: np.ndarray | None = None,
 ) -> (
     tuple[np.ndarray, float] | tuple[np.ndarray, float, np.ndarray, np.ndarray]
 ):
@@ -129,6 +130,10 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
         design variable. Overrides ``lb`` and ``ub`` when provided. Example::
 
             bounds = [(-1, 1), (0, 5)]  # two variables
+    init : array of shape (swarmsize, len(lb)), optional
+        Custom initial particle positions. Each row is one particle. Values
+        are clipped to ``[lb, ub]`` if any are out of range. When omitted,
+        positions are sampled uniformly at random (Default: None).
     pool : object with a map() method, optional
         A custom parallel-evaluation pool (e.g. ``multiprocessing.Pool``,
         ``ipyparallel.Client[:].map``, ``dask.distributed.Client``).
@@ -227,7 +232,17 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
         fg = np.inf  # best swarm position starting value
 
         # Initialize the particle's position
-        x = lb + x * (ub - lb)
+        if init is not None:
+            x = np.asarray(init, dtype=float)
+            if x.shape != (swarm_size, num_dims):
+                msg = (
+                    f"init must have shape ({swarm_size}, {num_dims}),"
+                    f" got {x.shape}"
+                )
+                raise ValueError(msg)
+            x = np.clip(x, lb, ub)
+        else:
+            x = lb + x * (ub - lb)
 
         # Calculate objective and constraints for each particle
         if mp_pool is not None:
@@ -332,9 +347,7 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
             it += 1
 
         if debug:
-            print(
-                f"Stopping search: maximum iterations reached --> {maxiter}"
-            )
+            print(f"Stopping search: maximum iterations reached --> {maxiter}")
 
         if not is_feasible(g):
             print(

--- a/pyswarm/pso.py
+++ b/pyswarm/pso.py
@@ -35,8 +35,8 @@ def _cons_f_ieqcons_wrapper(
 
 def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
     func: Callable,
-    lb: list | np.ndarray,
-    ub: list | np.ndarray,
+    lb: list | np.ndarray | None = None,
+    ub: list | np.ndarray | None = None,
     ieqcons: list | None = None,
     f_ieqcons: Callable | None = None,
     args: tuple = (),
@@ -53,6 +53,7 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
     particle_output: bool = False,  # noqa: FBT001, FBT002
     seed: int | None = None,
     patience: int = 0,
+    bounds: list[tuple[float, float]] | None = None,
 ) -> (
     tuple[np.ndarray, float] | tuple[np.ndarray, float, np.ndarray, np.ndarray]
 ):
@@ -63,10 +64,12 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
     ==========
     func : function
         The function to be minimized
-    lb : array
-        The lower bounds of the design variable(s)
-    ub : array
-        The upper bounds of the design variable(s)
+    lb : array, optional
+        The lower bounds of the design variable(s). Required if ``bounds``
+        is not provided.
+    ub : array, optional
+        The upper bounds of the design variable(s). Required if ``bounds``
+        is not provided.
 
     Optional
     ========
@@ -119,6 +122,11 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
         Useful for problems where the swarm reaches an exact optimum and no
         further improvement is possible (e.g. f(x)=0), preventing needless
         iterations until ``maxiter``.
+    bounds : list of (lo, hi) pairs, optional
+        SciPy-style bounds: a sequence of ``(lower, upper)`` tuples, one per
+        design variable. Overrides ``lb`` and ``ub`` when provided. Example::
+
+            bounds = [(-1, 1), (0, 5)]  # two variables
 
     Returns
     =======
@@ -144,6 +152,12 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
         kwargs = {}
     if ieqcons is None:
         ieqcons = []
+    if bounds is not None:
+        lb = [b[0] for b in bounds]
+        ub = [b[1] for b in bounds]
+    if lb is None or ub is None:
+        msg = "Either 'bounds' or both 'lb' and 'ub' must be provided"
+        raise ValueError(msg)
     if len(lb) != len(ub):
         msg = "Lower- and upper-bounds must be the same length"
         raise ValueError(msg)

--- a/pyswarm/pso.py
+++ b/pyswarm/pso.py
@@ -33,7 +33,7 @@ def _cons_f_ieqcons_wrapper(
     return np.array(f_ieqcons(x, *args, **kwargs))
 
 
-def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914
+def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
     func: Callable,
     lb: list | np.ndarray,
     ub: list | np.ndarray,
@@ -52,6 +52,7 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914
     processes: int = 1,
     particle_output: bool = False,  # noqa: FBT001, FBT002
     seed: int | None = None,
+    patience: int = 0,
 ) -> (
     tuple[np.ndarray, float] | tuple[np.ndarray, float, np.ndarray, np.ndarray]
 ):
@@ -112,6 +113,12 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914
     particle_output : boolean
         Whether to include the best per-particle position and the objective
         values at those.
+    patience : int
+        Maximum number of consecutive iterations without improvement before
+        terminating early. Set to 0 to disable plateau detection (Default: 0).
+        Useful for problems where the swarm reaches an exact optimum and no
+        further improvement is possible (e.g. f(x)=0), preventing needless
+        iterations until ``maxiter``.
 
     Returns
     =======
@@ -222,6 +229,7 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914
 
     # Iterate until termination criterion met ##################################
     it = 1
+    stagnation = 0  # consecutive iterations without improvement
     while it <= maxiter:
         rp = rng.uniform(size=(swarm_size, num_dims))
         rg = rng.uniform(size=(swarm_size, num_dims))
@@ -252,6 +260,7 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914
         # Compare swarm's best position with global best position
         i_min = np.argmin(fp)
         if fp[i_min] < fg:
+            stagnation = 0
             if debug:
                 print(
                     f"New best for swarm at iteration {it}: {p[i_min, :]} {fp[i_min]}"  # noqa: E501
@@ -261,30 +270,40 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914
             stepsize = np.sqrt(np.sum((g - p_min) ** 2))
 
             if np.abs(fg - fp[i_min]) <= minfunc:
-                print(
-                    f"Stopping search: Swarm best objective change less than {minfunc}"  # noqa: E501
-                )
+                if debug:
+                    print(
+                        f"Stopping search: Swarm best objective change less than {minfunc}"  # noqa: E501
+                    )
                 if particle_output:
                     return p_min, fp[i_min], p, fp
-                else:
-                    return p_min, fp[i_min]
-            elif stepsize <= minstep:
-                print(
-                    f"Stopping search: Swarm best position change less than {minstep}"  # noqa: E501
-                )
+                return p_min, fp[i_min]
+            if stepsize <= minstep:
+                if debug:
+                    print(
+                        f"Stopping search: Swarm best position change less than {minstep}"  # noqa: E501
+                    )
                 if particle_output:
                     return p_min, fp[i_min], p, fp
-                else:
-                    return p_min, fp[i_min]
-            else:
-                g = p_min.copy()
-                fg = fp[i_min]
+                return p_min, fp[i_min]
+            g = p_min.copy()
+            fg = fp[i_min]
+        else:
+            stagnation += 1
+            if patience > 0 and stagnation >= patience:
+                if debug:
+                    print(
+                        f"Stopping search: no improvement for {patience} consecutive iterations"  # noqa: E501
+                    )
+                if particle_output:
+                    return g, fg, p, fp
+                return g, fg
 
         if debug:
             print(f"Best after iteration {it}: {g} {fg}")
         it += 1
 
-    print(f"Stopping search: maximum iterations reached --> {maxiter}")
+    if debug:
+        print(f"Stopping search: maximum iterations reached --> {maxiter}")
 
     if not is_feasible(g):
         print(

--- a/pyswarm/pso.py
+++ b/pyswarm/pso.py
@@ -57,6 +57,7 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
     bounds: list[tuple[float, float]] | None = None,
     pool: object | None = None,
     init: np.ndarray | None = None,
+    intvar: list[int] | None = None,
 ) -> (
     tuple[np.ndarray, float] | tuple[np.ndarray, float, np.ndarray, np.ndarray]
 ):
@@ -130,6 +131,11 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
         design variable. Overrides ``lb`` and ``ub`` when provided. Example::
 
             bounds = [(-1, 1), (0, 5)]  # two variables
+    intvar : list of int, optional
+        Indices of design variables that must take integer values. After each
+        position update the selected dimensions are rounded to the nearest
+        integer and clipped to ``[lb, ub]``. Bounds for integer variables
+        should themselves be integers (Default: None).
     init : array of shape (swarmsize, len(lb)), optional
         Custom initial particle positions. Each row is one particle. Values
         are clipped to ``[lb, ub]`` if any are out of range. When omitted,
@@ -243,6 +249,8 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
             x = np.clip(x, lb, ub)
         else:
             x = lb + x * (ub - lb)
+        if intvar is not None:
+            x[:, intvar] = np.round(x[:, intvar]).clip(lb[intvar], ub[intvar])
 
         # Calculate objective and constraints for each particle
         if mp_pool is not None:
@@ -286,6 +294,10 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
             maskl = x < lb
             masku = x > ub
             x = x * (~np.logical_or(maskl, masku)) + lb * maskl + ub * masku
+            if intvar is not None:
+                x[:, intvar] = np.round(x[:, intvar]).clip(
+                    lb[intvar], ub[intvar]
+                )
 
             # Update objectives and constraints
             if mp_pool is not None:

--- a/pyswarm/pso.py
+++ b/pyswarm/pso.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import multiprocessing
 from collections.abc import Callable
 from functools import partial
+from typing import Any
 
 import numpy as np
 
@@ -54,6 +55,7 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
     seed: int | None = None,
     patience: int = 0,
     bounds: list[tuple[float, float]] | None = None,
+    pool: object | None = None,
 ) -> (
     tuple[np.ndarray, float] | tuple[np.ndarray, float, np.ndarray, np.ndarray]
 ):
@@ -127,6 +129,13 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
         design variable. Overrides ``lb`` and ``ub`` when provided. Example::
 
             bounds = [(-1, 1), (0, 5)]  # two variables
+    pool : object with a map() method, optional
+        A custom parallel-evaluation pool (e.g. ``multiprocessing.Pool``,
+        ``ipyparallel.Client[:].map``, ``dask.distributed.Client``).
+        When provided, the ``processes`` argument is ignored and the pool's
+        lifecycle is managed entirely by the caller. When omitted and
+        ``processes > 1``, an internal ``multiprocessing.Pool`` is created and
+        closed automatically (Default: None).
 
     Returns
     =======
@@ -194,71 +203,34 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
         cons = partial(_cons_f_ieqcons_wrapper, f_ieqcons, args, kwargs)
     is_feasible = partial(_is_feasible_wrapper, cons)
 
-    # Initialize the multiprocessing module if necessary
-    mp_pool = None
-    if processes > 1:
+    # Set up the evaluation pool.
+    owns_pool = False
+    if pool is not None:
+        mp_pool: Any = pool
+    elif processes > 1:
         mp_pool = multiprocessing.Pool(processes)
-
-    # Initialize the particle swarm ############################################
-    swarm_size = swarmsize
-    num_dims = len(lb)  # the number of dimensions each particle has
-    x = rng.random((swarm_size, num_dims))  # particle positions
-    v = np.zeros_like(x)  # particle velocities
-    p = np.zeros_like(x)  # best particle positions
-    fx = np.zeros(swarm_size)  # current particle function values
-    fs = np.zeros(swarm_size, dtype=bool)  # feasibility of each particle
-    fp = np.ones(swarm_size) * np.inf  # best particle function values
-    g = []  # best swarm position
-    fg = np.inf  # best swarm position starting value
-
-    # Initialize the particle's position
-    x = lb + x * (ub - lb)
-
-    # Calculate objective and constraints for each particle
-    if processes > 1:
-        fx = np.array(mp_pool.map(obj, x))
-        fs = np.array(mp_pool.map(is_feasible, x))
+        owns_pool = True
     else:
-        for i in range(swarm_size):
-            fx[i] = obj(x[i, :])
-            fs[i] = is_feasible(x[i, :])
+        mp_pool = None
 
-    # Store particle's best position (if constraints are satisfied)
-    i_update = np.logical_and((fx < fp), fs)
-    p[i_update, :] = x[i_update, :].copy()
-    fp[i_update] = fx[i_update]
+    try:
+        # Initialize the particle swarm ########################################
+        swarm_size = swarmsize
+        num_dims = len(lb)  # the number of dimensions each particle has
+        x = rng.random((swarm_size, num_dims))  # particle positions
+        v = np.zeros_like(x)  # particle velocities
+        p = np.zeros_like(x)  # best particle positions
+        fx = np.zeros(swarm_size)  # current particle function values
+        fs = np.zeros(swarm_size, dtype=bool)  # feasibility of each particle
+        fp = np.ones(swarm_size) * np.inf  # best particle function values
+        g = []  # best swarm position
+        fg = np.inf  # best swarm position starting value
 
-    # Update swarm's best position
-    i_min = np.argmin(fp)
-    if fp[i_min] < fg:
-        fg = fp[i_min]
-        g = p[i_min, :].copy()
-    else:
-        # At the start, there may not be any feasible starting point, so just
-        # give it a temporary "best" point since it's likely to change
-        g = x[0, :].copy()
+        # Initialize the particle's position
+        x = lb + x * (ub - lb)
 
-    # Initialize the particle's velocity
-    v = rng.uniform(vlow, vhigh, size=(swarm_size, num_dims))
-
-    # Iterate until termination criterion met ##################################
-    it = 1
-    stagnation = 0  # consecutive iterations without improvement
-    while it <= maxiter:
-        rp = rng.uniform(size=(swarm_size, num_dims))
-        rg = rng.uniform(size=(swarm_size, num_dims))
-
-        # Update the particles velocities
-        v = omega * v + phip * rp * (p - x) + phig * rg * (g - x)
-        # Update the particles' positions
-        x += v
-        # Correct for bound violations
-        maskl = x < lb
-        masku = x > ub
-        x = x * (~np.logical_or(maskl, masku)) + lb * maskl + ub * masku
-
-        # Update objectives and constraints
-        if processes > 1:
+        # Calculate objective and constraints for each particle
+        if mp_pool is not None:
             fx = np.array(mp_pool.map(obj, x))
             fs = np.array(mp_pool.map(is_feasible, x))
         else:
@@ -271,59 +243,107 @@ def pso(  # noqa: PLR0913, PLR0917, PLR0912, PLR0915, PLR0914, PLR0911
         p[i_update, :] = x[i_update, :].copy()
         fp[i_update] = fx[i_update]
 
-        # Compare swarm's best position with global best position
+        # Update swarm's best position
         i_min = np.argmin(fp)
         if fp[i_min] < fg:
-            stagnation = 0
-            if debug:
-                print(
-                    f"New best for swarm at iteration {it}: {p[i_min, :]} {fp[i_min]}"  # noqa: E501
-                )
-
-            p_min = p[i_min, :].copy()
-            stepsize = np.sqrt(np.sum((g - p_min) ** 2))
-
-            if np.abs(fg - fp[i_min]) <= minfunc:
-                if debug:
-                    print(
-                        f"Stopping search: Swarm best objective change less than {minfunc}"  # noqa: E501
-                    )
-                if particle_output:
-                    return p_min, fp[i_min], p, fp
-                return p_min, fp[i_min]
-            if stepsize <= minstep:
-                if debug:
-                    print(
-                        f"Stopping search: Swarm best position change less than {minstep}"  # noqa: E501
-                    )
-                if particle_output:
-                    return p_min, fp[i_min], p, fp
-                return p_min, fp[i_min]
-            g = p_min.copy()
             fg = fp[i_min]
+            g = p[i_min, :].copy()
         else:
-            stagnation += 1
-            if patience > 0 and stagnation >= patience:
+            # At the start, there may not be any feasible starting point, so
+            # give it a temporary "best" point since it's likely to change
+            g = x[0, :].copy()
+
+        # Initialize the particle's velocity
+        v = rng.uniform(vlow, vhigh, size=(swarm_size, num_dims))
+
+        # Iterate until termination criterion met ##############################
+        it = 1
+        stagnation = 0  # consecutive iterations without improvement
+        while it <= maxiter:
+            rp = rng.uniform(size=(swarm_size, num_dims))
+            rg = rng.uniform(size=(swarm_size, num_dims))
+
+            # Update the particles velocities
+            v = omega * v + phip * rp * (p - x) + phig * rg * (g - x)
+            # Update the particles' positions
+            x += v
+            # Correct for bound violations
+            maskl = x < lb
+            masku = x > ub
+            x = x * (~np.logical_or(maskl, masku)) + lb * maskl + ub * masku
+
+            # Update objectives and constraints
+            if mp_pool is not None:
+                fx = np.array(mp_pool.map(obj, x))
+                fs = np.array(mp_pool.map(is_feasible, x))
+            else:
+                for i in range(swarm_size):
+                    fx[i] = obj(x[i, :])
+                    fs[i] = is_feasible(x[i, :])
+
+            # Store particle's best position (if constraints are satisfied)
+            i_update = np.logical_and((fx < fp), fs)
+            p[i_update, :] = x[i_update, :].copy()
+            fp[i_update] = fx[i_update]
+
+            # Compare swarm's best position with global best position
+            i_min = np.argmin(fp)
+            if fp[i_min] < fg:
+                stagnation = 0
                 if debug:
                     print(
-                        f"Stopping search: no improvement for {patience} consecutive iterations"  # noqa: E501
+                        f"New best for swarm at iteration {it}: {p[i_min, :]} {fp[i_min]}"  # noqa: E501
                     )
-                if particle_output:
-                    return g, fg, p, fp
-                return g, fg
+
+                p_min = p[i_min, :].copy()
+                stepsize = np.sqrt(np.sum((g - p_min) ** 2))
+
+                if np.abs(fg - fp[i_min]) <= minfunc:
+                    if debug:
+                        print(
+                            f"Stopping search: Swarm best objective change less than {minfunc}"  # noqa: E501
+                        )
+                    if particle_output:
+                        return p_min, fp[i_min], p, fp
+                    return p_min, fp[i_min]
+                if stepsize <= minstep:
+                    if debug:
+                        print(
+                            f"Stopping search: Swarm best position change less than {minstep}"  # noqa: E501
+                        )
+                    if particle_output:
+                        return p_min, fp[i_min], p, fp
+                    return p_min, fp[i_min]
+                g = p_min.copy()
+                fg = fp[i_min]
+            else:
+                stagnation += 1
+                if patience > 0 and stagnation >= patience:
+                    if debug:
+                        print(
+                            f"Stopping search: no improvement for {patience} consecutive iterations"  # noqa: E501
+                        )
+                    if particle_output:
+                        return g, fg, p, fp
+                    return g, fg
+
+            if debug:
+                print(f"Best after iteration {it}: {g} {fg}")
+            it += 1
 
         if debug:
-            print(f"Best after iteration {it}: {g} {fg}")
-        it += 1
+            print(
+                f"Stopping search: maximum iterations reached --> {maxiter}"
+            )
 
-    if debug:
-        print(f"Stopping search: maximum iterations reached --> {maxiter}")
-
-    if not is_feasible(g):
-        print(
-            "However, the optimization couldn't find a feasible design. Sorry"
-        )
-    if particle_output:
-        return g, fg, p, fp
-    else:
+        if not is_feasible(g):
+            print(
+                "However, the optimization couldn't find a feasible design. Sorry"  # noqa: E501
+            )
+        if particle_output:
+            return g, fg, p, fp
         return g, fg
+    finally:
+        if owns_pool and mp_pool is not None:
+            mp_pool.terminate()
+            mp_pool.join()

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -1,0 +1,25 @@
+import numpy as np
+from numpy.typing import NDArray
+
+from pyswarm.pso import pso
+
+
+def banana_func(x: NDArray[np.floating]) -> np.floating:
+    x1 = x[0]
+    x2 = x[1]
+    return x1**4 - 2 * x2 * x1**2 + x2**2 + x1**2 - 2 * x1 + 5
+
+
+def test_scipy_bounds_matches_lb_ub() -> None:
+    bounds = [(-3, 2), (-1, 6)]
+    xopt_b, fopt_b = pso(banana_func, bounds=bounds, seed=42)
+    xopt_lbub, fopt_lbub = pso(banana_func, lb=[-3, -1], ub=[2, 6], seed=42)
+    if not np.allclose(xopt_b, xopt_lbub):
+        msg = (
+            "bounds and lb/ub should produce identical results:"
+            f" {xopt_b} vs {xopt_lbub}"
+        )
+        raise AssertionError(msg)
+    if not np.isclose(fopt_b, fopt_lbub):
+        msg = f"fopt mismatch: {fopt_b} vs {fopt_lbub}"
+        raise AssertionError(msg)

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from pyswarm.pso import pso
+
+
+def test_minfunc_plateau_terminates_early() -> None:
+    call_count = 0
+
+    def flat_func(x: np.ndarray) -> float:
+        nonlocal call_count
+        call_count += 1
+        return 0.0
+
+    result = pso(flat_func, [-1, -1], [1, 1], maxiter=500, seed=0, patience=1)
+    fopt = result[1]
+    if not np.isclose(fopt, 0.0):
+        msg = f"Expected fopt == 0.0, got {fopt}"
+        raise AssertionError(msg)
+    # With patience=1 the search stops after the first non-improving iteration.
+    # Without the fix the algorithm exhausts all 500 * swarmsize evaluations.
+    if call_count >= 500 * 100:
+        msg = f"Expected early stop, got {call_count} calls"
+        raise AssertionError(msg)
+
+
+def test_patience_zero_runs_to_maxiter() -> None:
+    call_count = 0
+
+    def flat_func(x: np.ndarray) -> float:
+        nonlocal call_count
+        call_count += 1
+        return 0.0
+
+    pso(flat_func, [-1, -1], [1, 1], maxiter=10, swarmsize=5, seed=0)
+    # 5 particles * (1 init eval + 10 loop iters) = 55 calls
+    expected = 5 + 10 * 5
+    if call_count != expected:
+        msg = f"Expected {expected} calls, got {call_count}"
+        raise AssertionError(msg)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,37 @@
+import numpy as np
+from numpy.typing import NDArray
+
+from pyswarm.pso import pso
+
+
+def banana_func(x: NDArray[np.floating]) -> np.floating:
+    x1 = x[0]
+    x2 = x[1]
+    return x1**4 - 2 * x2 * x1**2 + x2**2 + x1**2 - 2 * x1 + 5
+
+
+def test_init_positions_respected() -> None:
+    rng = np.random.default_rng(0)
+    lb, ub = np.array([-3.0, -1.0]), np.array([2.0, 6.0])
+    swarmsize = 20
+    init = lb + rng.random((swarmsize, 2)) * (ub - lb)
+    xopt, fopt = pso(
+        banana_func, lb, ub, swarmsize=swarmsize, init=init, seed=0
+    )
+    if not np.allclose(xopt, [1.0, 1.0], atol=0.1):
+        msg = f"Expected xopt near [1, 1], got {xopt}"
+        raise AssertionError(msg)
+    if not np.isclose(fopt, 4.0, atol=0.1):
+        msg = f"Expected fopt near 4.0, got {fopt}"
+        raise AssertionError(msg)
+
+
+def test_init_wrong_shape_raises() -> None:
+    bad_init = np.zeros((5, 3))
+    try:
+        pso(banana_func, [-1, -1], [1, 1], swarmsize=10, init=bad_init)
+    except ValueError:
+        pass
+    else:
+        msg = "Expected ValueError for wrong init shape"
+        raise AssertionError(msg)

--- a/tests/test_intvar.py
+++ b/tests/test_intvar.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from pyswarm.pso import pso
+
+
+def integer_func(x: np.ndarray) -> float:
+    # Minimised at x=[2, 3] with f=0; both variables should be integers.
+    return float((x[0] - 2) ** 2 + (x[1] - 3) ** 2)
+
+
+def test_intvar_solutions_are_integers() -> None:
+    lb = [0, 0]
+    ub = [5, 5]
+    xopt, fopt = pso(
+        integer_func, lb, ub, intvar=[0, 1], swarmsize=30, seed=0, maxiter=200
+    )
+    if not np.allclose(xopt, np.round(xopt)):
+        msg = f"Expected integer solution, got {xopt}"
+        raise AssertionError(msg)
+    if not np.isclose(fopt, 0.0, atol=0.1):
+        msg = f"Expected fopt near 0.0, got {fopt}"
+        raise AssertionError(msg)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,28 @@
+import multiprocessing
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pyswarm.pso import pso
+
+
+def banana_func(x: NDArray[np.floating]) -> np.floating:
+    x1 = x[0]
+    x2 = x[1]
+    return x1**4 - 2 * x2 * x1**2 + x2**2 + x1**2 - 2 * x1 + 5
+
+
+def test_custom_pool_matches_single_process() -> None:
+    lb, ub = [-3, -1], [2, 6]
+    xopt_single, fopt_single = pso(banana_func, lb, ub, seed=7)
+    with multiprocessing.Pool(2) as p:
+        xopt_pool, fopt_pool = pso(banana_func, lb, ub, seed=7, pool=p)
+    if not np.allclose(xopt_single, xopt_pool):
+        msg = (
+            "pool and single-process results differ:"
+            f" {xopt_single} vs {xopt_pool}"
+        )
+        raise AssertionError(msg)
+    if not np.isclose(fopt_single, fopt_pool):
+        msg = f"fopt mismatch: {fopt_single} vs {fopt_pool}"
+        raise AssertionError(msg)


### PR DESCRIPTION
## Summary

This PR addresses the concrete, solvable problems from the backlog of closed stale issues and PRs. Each commit is self-contained and references the original issue(s) it closes.

| Commit | Fixes | What |
|--------|-------|------|
| `1c93b1e` | #20, #22 | Gate **all** stopping messages on `debug`; add `patience` param for plateau early-stop |
| `d221828` | #5, #6 | SciPy-style `bounds` parameter (backwards-compatible) |
| `1943564` | #12, #16 | Custom `pool` parameter; **fix resource leak** (pool was never closed) |
| `c048faa` | #21 | `init` parameter for warm-start / fixed initial positions |
| `50a9a42` | #14, #17 | `intvar` parameter for mixed-integer PSO |

## Decisions / trade-offs

- **`patience` (issue #22)**: A `patience=0` default means the old plateau-ignoring behaviour is preserved. Setting `patience=N` stops after N consecutive non-improving iterations — this is the clean, composable fix vs. silently changing `minfunc` semantics.
- **`bounds` (issues #5/#6)**: `lb`/`ub` are now optional keyword args; callers using positional args are unaffected.
- **`pool` (PRs #12/#16)**: When the caller supplies a pool we never touch its lifecycle. When we create one internally (`processes > 1`) we now correctly terminate/join it via `try/finally`, fixing the silent resource leak in the original code.
- **`intvar` (issues #14/#17)**: Rounding happens after both initial placement and each bound-correction step; values are clipped to `[lb[i], ub[i]]` so they stay in range.
- **Skipped**: equality constraints (#8), infeasible-evaluation skip (#19), binary PSO (#10) — these require deeper design decisions or are out of scope.

## Test plan

- [x] All 10 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff lint clean (`uv run ruff check pyswarm/pso.py`)
- [x] Each new feature has at least one dedicated test
- [x] Existing twobar-truss seed=0 regression test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)