### PR TITLE
Fix Test workflow failing with an empty Python matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,23 @@ jobs:
       - name: Fetch Supported Python
         id: fetch-versions
         run: |
-          versions=$(curl -fsSL https://endoflife.date/api/v1/products/python/ \
-                     | jq '[ .result.releases[] | select(.isEol == false) | .label ]')
+          # Without pipefail this pipeline reports jq's exit status, not
+          # curl's, so a network failure is masked: jq reads empty input,
+          # emits [], and the matrix expands to zero jobs. build-and-test
+          # then never gets created and the run fails with no failing step.
+          set -euo pipefail
 
-          echo "supported_versions=$(echo $versions | jq -c '.')"        >> $GITHUB_OUTPUT
-          echo "bound_versions=$(echo $versions | jq -c '[.[0],.[-1]]')" >> $GITHUB_OUTPUT
+          versions=$(curl -fsSL --retry 3 --retry-all-errors --connect-timeout 15 \
+                       https://endoflife.date/api/v1/products/python/ \
+                     | jq -c '[ .result.releases[] | select(.isEol == false) | .label ]')
+
+          if [ "$(echo "$versions" | jq 'length')" -eq 0 ]; then
+            echo "::error::endoflife.date returned no supported Python versions"
+            exit 1
+          fi
+
+          echo "supported_versions=$versions"                              >> $GITHUB_OUTPUT
+          echo "bound_versions=$(echo "$versions" | jq -c '[.[0],.[-1]]')" >> $GITHUB_OUTPUT
 
   build-and-test:
     name: Build and Test


### PR DESCRIPTION
The `Test` workflow has been failing with **no failing step** — only
`fetch-python-versions` ran, it reported success, and `build-and-test`
was never created.

## Cause

The version fetch is a pipeline:

```bash
versions=$(curl -fsSL https://endoflife.date/... | jq "[...]")
```

Without `pipefail`, a pipeline reports the **last** command's exit status,
so `curl` failing is invisible: `jq` reads empty input, emits `[]`, and the
matrix expands to **zero jobs**. GitHub then fails the run with nothing to
attribute it to. The log of run [30890495192](https://github.com/eggzec/pyswarm/actions/runs/30890495192) confirms it:

```
curl: (28) Failed to connect to endoflife.date port 443 after 270172 ms
```

So this was a transient network blip silently converted into a broken matrix
— not a code or toolchain problem.

## Fix

- `set -euo pipefail` so the step fails at the real cause
- `--retry 3 --retry-all-errors --connect-timeout 15` to ride out blips
- an explicit empty-list check, so a zero-length matrix can never be emitted

Verified under `bash -e <file>` (exactly how Actions invokes `run:`): the old
form exits 0 with an empty value, the new form exits 1.

Note: every repo in the org shares this block and is vulnerable to the same
silent failure. Happy to follow up across the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)